### PR TITLE
feat(aggregator): basic JSON-RPC API version mgmt

### DIFF
--- a/tap_aggregator/Cargo.toml
+++ b/tap_aggregator/Cargo.toml
@@ -18,6 +18,7 @@ clap = { version = "4.2.4", features = ["derive", "env"] }
 ethers-core = "2.0.3"
 serde = { version = "1.0.163", features = ["derive"] }
 serde_json = { version = "1.0.96", features = ["raw_value"] }
+strum = { version = "0.24.1", features = ["strum_macros", "derive"] }
 
 [dev-dependencies]
 jsonrpsee = { version = "0.18.0", features = ["http-client", "jsonrpsee-core"] }

--- a/tap_aggregator/Cargo.toml
+++ b/tap_aggregator/Cargo.toml
@@ -16,6 +16,8 @@ jsonrpsee = { version = "0.18.0", features = ["server", "macros"] }
 ethers-signers = "2.0.3"
 clap = { version = "4.2.4", features = ["derive", "env"] }
 ethers-core = "2.0.3"
+serde = { version = "1.0.163", features = ["derive"] }
+serde_json = { version = "1.0.96", features = ["raw_value"] }
 
 [dev-dependencies]
 jsonrpsee = { version = "0.18.0", features = ["http-client", "jsonrpsee-core"] }

--- a/tap_aggregator/Cargo.toml
+++ b/tap_aggregator/Cargo.toml
@@ -3,6 +3,7 @@ name="tap_aggregator"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+readme = "README.md"
 
 [[bin]]
 name = "tap_aggregator"

--- a/tap_aggregator/README.md
+++ b/tap_aggregator/README.md
@@ -1,0 +1,157 @@
+# TAP Aggregator
+
+A JSON-RPC service that lets clients request an aggregate receipt from a list of individual receipts.
+
+## JSON-RPC API
+
+### Common interface
+
+The request format is standard, as described in [the official spec](https://www.jsonrpc.org/specification#request_object).
+
+If the call is successful, the response format is as described in [the official spec](https://www.jsonrpc.org/specification#response_object).
+In particular, the `result` field is of the form:
+
+| Field         | Type      | Description                                                                                              |
+| ------------- | --------- | -------------------------------------------------------------------------------------------------------- |
+| `data`        | `Object`  | The response data. Method specific, see each method's documentation.                                     |
+| `warnings`    | `Array`   | (Optional) A list of warnings. If the list is empty, no warning field is added to the JSON-RPC response. |
+
+WARNING: Always check for warnings!
+
+Warning object format (similar to the standard JSON-RPC error object):
+
+| Field         | Type      | Description                                                                           |
+| ------------- | --------- | ------------------------------------------------------------------------------------- |
+| `code`        | `Integer` | A number that indicates the error type that occurred.                                 |
+| `message`     | `String`  | A short description of the error.                                                     |
+| `data`        | `Object`  | A primitive or structured value that contains additional information about the error. |
+
+If the call fails, the response format is as described in [the official spec](https://www.jsonrpc.org/specification#error_object).
+
+### Methods
+
+#### `api_versions`
+
+[source](server::RpcServer::api_versions)
+
+Returns the versions of the TAP JSON-RPC API implemented by this server.
+
+Example:
+
+*Request*:
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 0,
+    "method": "api_versions",
+    "params": [
+        null
+    ]
+}
+```
+
+*Response*:
+
+```json
+{
+    "id": 0,
+    "jsonrpc": "2.0",
+    "result": {
+        "data": {
+            "versions_deprecated": [
+               "0.0"
+            ],
+            "versions_supported": [
+                "0.0",
+                "0.1"
+            ]
+        }
+    }
+}
+```
+
+#### `aggregate_receipts`
+
+[source](server::RpcServer::aggregate_receipts)
+
+Aggregates the given receipts into a receipt aggregate voucher.
+Returns an error if the user expected API version is not supported.
+
+Example:
+
+*Request*:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 0,
+  "method": "aggregate_receipts",
+  "params": [
+    "0.0",
+    [
+      {
+        "message": {
+          "allocation_id": "0xabababababababababababababababababababab",
+          "timestamp_ns": 1685670449225087255,
+          "nonce": 11835827017881841442,
+          "value": 34
+        },
+        "signature": {
+          "r": "0xa9fa1acf3cc3be503612f75602e68cc22286592db1f4f944c78397cbe529353b",
+          "s": "0x566cfeb7e80a393021a443d5846c0734d25bcf54ed90d97effe93b1c8aef0911",
+          "v": 27
+        }
+      },
+      {
+        "message": {
+          "allocation_id": "0xabababababababababababababababababababab",
+          "timestamp_ns": 1685670449225830106,
+          "nonce": 17711980309995246801,
+          "value": 23
+        },
+        "signature": {
+          "r": "0x51ca5a2b839558654326d3a3f544a97d94effb9a7dd9cac7492007bc974e91f0",
+          "s": "0x3d9d398ea6b0dd9fac97726f51c0840b8b314821fb4534cb40383850c431fd9e",
+          "v": 28
+        }
+      }
+    ],
+    {
+      "message": {
+        "allocation_id": "0xabababababababababababababababababababab",
+        "timestamp_ns": 1685670449224324338,
+        "value_aggregate": 101
+      },
+      "signature": {
+        "r": "0x601a1f399cf6223d1414a89b7bbc90ee13eeeec006bd59e0c96042266c6ad7dc",
+        "s": "0x3172e795bd190865afac82e3a8be5f4ccd4b65958529986c779833625875f0b2",
+        "v": 28
+      }
+    }
+  ]
+}
+```
+
+*Response*:
+
+```json
+{
+  "id": 0,
+  "jsonrpc": "2.0",
+  "result": {
+    "data": {
+      "message": {
+        "allocation_id": "0xabababababababababababababababababababab",
+        "timestamp_ns": 1685670449225830106,
+        "value_aggregate": 158
+      },
+      "signature": {
+        "r": "0x60eb38374119bbabf1ac6960f532124ba2a9c5990d9fb50875b512e611847eb5",
+        "s": "0x1b9a330cc9e2ecbda340a4757afaee8f55b6dbf278428f8cf49dd5ad8438f83d",
+        "v": 27
+      }
+    }
+  }
+}
+```

--- a/tap_aggregator/src/api_versioning.rs
+++ b/tap_aggregator/src/api_versioning.rs
@@ -1,0 +1,89 @@
+// Copyright 2023-, Semiotic AI, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::str::FromStr;
+
+use jsonrpsee::core::Serialize;
+use serde::Deserialize;
+use strum::{self, IntoEnumIterator};
+
+/// The versions of the TAP JSON-RPC API implemented by this server.
+/// The version numbers are independent of the TAP software version. As such, we are
+/// enabling the introduction of breaking changes to the TAP library interface without
+/// necessarily introducing breaking changes to the JSON-RPC API (or vice versa).
+#[derive(
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    strum::Display,
+    strum::EnumString,
+    strum::EnumVariantNames,
+    strum::EnumIter,
+)]
+pub enum TapRpcApiVersion {
+    #[strum(serialize = "0.0")]
+    V0_0,
+}
+
+// We implement our own Serialize and Deserialize traits for `TapRpcApiVersion` because
+// the ones derived by `serde` serialize the enum member names as strings (eg. "V0_0"),
+// while we want to serialize them using the variant strings we set through `strum`
+// (eg. "0.0").
+
+impl serde::ser::Serialize for TapRpcApiVersion {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::ser::Serializer,
+    {
+        serializer.serialize_str(self.to_string().as_str())
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for TapRpcApiVersion {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<TapRpcApiVersion, D::Error>
+    where
+        D: serde::de::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        TapRpcApiVersion::from_str(&s).map_err(serde::de::Error::custom)
+    }
+}
+
+/// List of RPC version numbers for which a deprecation warning has to be issued.
+/// This is a very basic approach to deprecation warnings. The most important thing
+/// is to have *some* process in place to warn users of breaking changes.
+/// NOTE: Make sure to test it when that list becomes non-empty.
+pub static TAP_RPC_API_VERSIONS_DEPRECATED: &[TapRpcApiVersion] = &[];
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct TapRpcApiVersionsInfo {
+    pub versions_supported: Vec<TapRpcApiVersion>,
+    pub versions_deprecated: Vec<TapRpcApiVersion>,
+}
+
+pub fn tap_rpc_api_versions_info() -> TapRpcApiVersionsInfo {
+    TapRpcApiVersionsInfo {
+        versions_supported: TapRpcApiVersion::iter().collect::<Vec<_>>(),
+        versions_deprecated: TAP_RPC_API_VERSIONS_DEPRECATED.to_vec(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_tap_rpc_api_version_serialize() {
+        let version = TapRpcApiVersion::V0_0;
+        let serialized = serde_json::to_string(&version).unwrap();
+        assert_eq!(serialized, "\"0.0\"");
+    }
+
+    #[test]
+    fn test_tap_rpc_api_version_deserialize() {
+        let version = TapRpcApiVersion::V0_0;
+        let deserialized: TapRpcApiVersion = serde_json::from_str("\"0.0\"").unwrap();
+        assert_eq!(deserialized, version);
+    }
+}

--- a/tap_aggregator/src/error_codes.rs
+++ b/tap_aggregator/src/error_codes.rs
@@ -1,0 +1,20 @@
+// Copyright 2023-, Semiotic AI, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// JSON-RPC error codes specific to the TAP aggregator.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum JsonRpcErrorCode {
+    /// -32001 -- Invalid API version.
+    InvalidVersionError = -32001,
+    /// -32002 -- Error during receipt aggregation.
+    AggregationError = -32002,
+}
+
+/// JSON-RPC warning codes
+/// These are not part of the JSON-RPC spec, but are used to provide additional information to the
+/// client.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum JsonRpcWarningCode {
+    /// -32101 -- Requested API version is deprecated.
+    DeprecatedVersionWarning = -32101,
+}

--- a/tap_aggregator/src/jsonrpsee_helpers.rs
+++ b/tap_aggregator/src/jsonrpsee_helpers.rs
@@ -1,0 +1,58 @@
+// Copyright 2023-, Semiotic AI, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use jsonrpsee::core::Serialize;
+use serde::Deserialize;
+use serde_json::value::Value;
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct JsonRpcWarning {
+    code: i32,
+    message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    data: Option<Value>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct JsonRpcResponse<T: Serialize> {
+    pub data: T,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub warnings: Option<Vec<JsonRpcWarning>>,
+}
+
+pub type JsonRpcError = jsonrpsee::types::ErrorObjectOwned;
+pub type JsonRpcResult<T> = Result<JsonRpcResponse<T>, JsonRpcError>;
+
+impl<T: Serialize> JsonRpcResponse<T> {
+    /// Helper method that returns a JsonRpcResponse with the given data and no warnings.
+    pub fn ok(data: T) -> Self {
+        JsonRpcResponse {
+            data,
+            warnings: None,
+        }
+    }
+
+    /// Helper method that returns a JsonRpcResponse with the given data and warnings.
+    /// If the warnings vector is empty, no warning field is added to the JSON-RPC response.
+    pub fn warn(data: T, warnings: Vec<JsonRpcWarning>) -> Self {
+        JsonRpcResponse {
+            data,
+            warnings: if warnings.is_empty() {
+                None
+            } else {
+                Some(warnings)
+            },
+        }
+    }
+}
+
+impl JsonRpcWarning {
+    pub fn new<S: Serialize>(code: i32, message: String, data: Option<S>) -> Self {
+        JsonRpcWarning {
+            code,
+            message,
+            data: data.and_then(|d| serde_json::to_value(&d).ok()),
+        }
+    }
+}

--- a/tap_aggregator/src/main.rs
+++ b/tap_aggregator/src/main.rs
@@ -10,6 +10,7 @@ use tokio::signal::unix::{signal, SignalKind};
 
 mod aggregator;
 mod api_versioning;
+mod error_codes;
 mod jsonrpsee_helpers;
 mod server;
 

--- a/tap_aggregator/src/main.rs
+++ b/tap_aggregator/src/main.rs
@@ -1,6 +1,8 @@
 // Copyright 2023-, Semiotic AI, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+#![doc = include_str!("../README.md")]
+
 use anyhow::Result;
 use clap::Parser;
 use ethers_signers::{coins_bip39::English, MnemonicBuilder};

--- a/tap_aggregator/src/main.rs
+++ b/tap_aggregator/src/main.rs
@@ -7,6 +7,8 @@ use ethers_signers::{coins_bip39::English, MnemonicBuilder};
 use tokio::signal::unix::{signal, SignalKind};
 
 mod aggregator;
+mod api_versioning;
+mod jsonrpsee_helpers;
 mod server;
 
 #[derive(Parser, Debug)]

--- a/tap_aggregator/src/server.rs
+++ b/tap_aggregator/src/server.rs
@@ -16,6 +16,7 @@ use crate::api_versioning::{
     tap_rpc_api_versions_info, TapRpcApiVersion, TapRpcApiVersionsInfo,
     TAP_RPC_API_VERSIONS_DEPRECATED,
 };
+use crate::error_codes::{JsonRpcErrorCode, JsonRpcWarningCode};
 use crate::jsonrpsee_helpers::{JsonRpcError, JsonRpcResponse, JsonRpcResult, JsonRpcWarning};
 use tap_core::{
     eip_712_signed_message::EIP712SignedMessage,
@@ -54,7 +55,7 @@ struct RpcImpl {
 fn parse_api_version(api_version: &str) -> Result<TapRpcApiVersion, JsonRpcError> {
     TapRpcApiVersion::from_str(api_version).map_err(|_| {
         jsonrpsee::types::ErrorObject::owned(
-            -32001,
+            JsonRpcErrorCode::InvalidVersionError as i32,
             format!("Unsupported API version: \"{}\".", api_version),
             Some(tap_rpc_api_versions_info()),
         )
@@ -66,7 +67,7 @@ fn parse_api_version(api_version: &str) -> Result<TapRpcApiVersion, JsonRpcError
 fn check_api_version_deprecation(api_version: &TapRpcApiVersion) -> Option<JsonRpcWarning> {
     if TAP_RPC_API_VERSIONS_DEPRECATED.contains(api_version) {
         Some(JsonRpcWarning::new(
-            -32002,
+            JsonRpcWarningCode::DeprecatedVersionWarning as i32,
             format!(
                 "The API version {} will be deprecated. \
                 Please check https://github.com/semiotic-ai/timeline_aggregation_protocol for more information.",
@@ -110,7 +111,7 @@ impl RpcServer for RpcImpl {
         match res {
             Ok(res) => Ok(JsonRpcResponse::warn(res, warnings)),
             Err(e) => Err(jsonrpsee::types::ErrorObject::owned(
-                -32000,
+                JsonRpcErrorCode::AggregationError as i32,
                 e.to_string(),
                 None::<()>,
             )),

--- a/tap_aggregator/src/server.rs
+++ b/tap_aggregator/src/server.rs
@@ -215,12 +215,10 @@ mod tests {
         let client = HttpClientBuilder::default()
             .build(format!("http://127.0.0.1:{}", local_addr.port()))
             .unwrap();
-        let res: server::JsonRpcResponse<server::TapRpcApiVersionsInfo> = client
+        let _: server::JsonRpcResponse<server::TapRpcApiVersionsInfo> = client
             .request("api_versions", rpc_params!(None::<()>))
             .await
             .unwrap();
-
-        println!("{:?}", res);
 
         handle.stop().unwrap();
         handle.stopped().await;
@@ -404,8 +402,6 @@ mod tests {
                 rpc_params!("invalid version string", &receipts, None::<()>),
             )
             .await;
-
-        println!("{:#?}", res);
 
         assert!(res.is_err());
 

--- a/tap_aggregator/src/server.rs
+++ b/tap_aggregator/src/server.rs
@@ -72,7 +72,7 @@ fn check_api_version_deprecation(api_version: &TapRpcApiVersion) -> Option<JsonR
                 Please check https://github.com/semiotic-ai/timeline_aggregation_protocol for more information.",
                 api_version
             ),
-            None::<()>,
+            Some(tap_rpc_api_versions_info()),
         ))
     } else {
         None

--- a/tap_aggregator/src/server.rs
+++ b/tap_aggregator/src/server.rs
@@ -23,6 +23,11 @@ use tap_core::{
 };
 
 /// Generates the `RpcServer` trait that is used to define the JSON-RPC API.
+///
+/// Note that because of the way the `rpc` macro works, we cannot document the RpcServer trait here.
+/// (So even this very docstring will not appear in the generated documentation...)
+/// As a result, we document the JSON-RPC API in the `tap_aggregator/README.md` file.
+/// Do not forget to update the documentation there if you make any changes to the JSON-RPC API.
 #[rpc(server)]
 pub trait Rpc {
     /// Returns the versions of the TAP JSON-RPC API implemented by this server.


### PR DESCRIPTION
By API, here we mean specifically the TAP JSON-RPC API version, not the library version.

Maintains a const list of supported API versions, as well as a const list of API versions for which to warn of imminent deprecation. We expect the client to periodically check if its expected API version is deprecated.
For all functions, an expected API version is to be supplied as argument. Each function will have to check if the number is supported, and return an error otherwise.

Rationale:
- The JSON-RPC spec does not allow for deprecation messages. All non-error responses have to be HTTP 204. The design is the result of trying not to break the JSON-RPC spec.
- This is designed for maximum flexibility. The primary goal is to have a reasonable public API. The actual implementation can be improved in the future.
- Enables support for and discovery of multiple API versions from day 0.
- Enables a way to warn users of future version deprecations from day 0.

Some of those features may not be needed, but at least there is a low chance that we get stuck when the need to migrate to a new API version arises.

Please comment!

fixes #79  (hopefully!)